### PR TITLE
feat: upgrade virtool to 36.24.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,4 +37,4 @@ select = ["ALL"]
 "tests/**" = ["ANN201", "ANN202", "D205", "S101", "S106"]
 
 [tool.uv.sources]
-virtool = { git = "https://github.com/virtool/virtool", tag = "36.19.1" }
+virtool = { git = "https://github.com/virtool/virtool", tag = "36.24.0" }

--- a/uv.lock
+++ b/uv.lock
@@ -1212,7 +1212,7 @@ wheels = [
 [[package]]
 name = "virtool"
 version = "0.0.0"
-source = { git = "https://github.com/virtool/virtool?tag=36.19.1#5e8cee133d854b40e20470eee6c5a666755d2f19" }
+source = { git = "https://github.com/virtool/virtool?tag=36.24.0#b2ea9f289d1b522ddb1d70491cb3a647cc600a65" }
 dependencies = [
     { name = "aiofiles" },
     { name = "aiohttp", extra = ["speedups"] },
@@ -1275,7 +1275,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "virtool", git = "https://github.com/virtool/virtool?tag=36.19.1" }]
+requires-dist = [{ name = "virtool", git = "https://github.com/virtool/virtool?tag=36.24.0" }]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary
- Upgrades the `virtool` dependency from tag `36.19.1` to `36.24.0`
- Updates `pyproject.toml` and `uv.lock` to reflect the new version

## Test plan
- [ ] Verify the workflow runs successfully with the upgraded virtool version
- [ ] Confirm no regressions in NuVs output